### PR TITLE
Necessary changes because of the issue #86(Highlight states with warning...) in AutomatonBuilderGUI project

### DIFF
--- a/src/AutomatonElement.ts
+++ b/src/AutomatonElement.ts
@@ -1,3 +1,10 @@
 import BaseAutomaton from "./BaseAutomaton";
 
-export default class AutomatonElement<T extends BaseAutomaton> {}
+export default class AutomatonElement<T extends BaseAutomaton> {
+    public label?: string;
+  
+    constructor(label?: string) {
+      this.label = label;
+    }
+}
+  

--- a/src/AutomatonState.ts
+++ b/src/AutomatonState.ts
@@ -2,9 +2,8 @@ import AutomatonElement from './AutomatonElement';
 import BaseAutomaton from './BaseAutomaton';
 
 export default class AutomatonState<T extends BaseAutomaton> extends AutomatonElement<T> {
-  constructor(
-    public label: string | undefined = undefined
-  ) {
-    super();
+  constructor(label?: string) {
+    super(label);
   }
+
 }


### PR DESCRIPTION
Reason for Changes
  -Enable Element Labeling: Labels are necessary for identifying automaton elements, especially when handling errors or displaying elements in a GUI.
  -In the main project(AutomatonBuilderGUI ), we needed to access element.label to highlight nodes associated with errors and to display labels in the UI.

This pull request introduces a label property to the AutomatonElement class and updates the AutomatonState class to handle labels appropriately. These changes enable automaton elements to have labels, which are essential for identifying elements during error handling and for displaying labels in user interfaces.
Changes Made
1. Updated AutomatonElement.ts
    I added an pptional label property: label?: string which allows instances of AutomatonElement and its subclasses to have an associated label.
2. Updated AutomatonState.ts
    I adjusted constructor: to accept an optional label parameter and pass it to the superclass which ensures that the label is properly initialized in the base AutomatonElement class.